### PR TITLE
fix(security): pin trivy-action to SHA to mitigate supply chain attack

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: 'ops/'


### PR DESCRIPTION
## Summary

- Pin `aquasecurity/trivy-action` to a full commit SHA instead of a mutable tag/branch reference
- This mitigates the [Trivy GitHub Action supply chain attack](https://thehackernews.com/2026/03/trivy-security-scanner-github-actions.html) where 75 of 76 version tags were force-pushed with an infostealer payload

## What happened

An attacker compromised credentials for the `aquasecurity/trivy-action` repository and force-pushed malicious code to 75 out of 76 version tags. Any workflow referencing these tags (or `master`) would pull the compromised code, which exfiltrates CI secrets (SSH keys, cloud credentials, tokens) to an attacker-controlled domain.

## What this PR does

Pins the action to the known-safe commit SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0) so that even if tags are manipulated again in the future, the workflow will continue to use the verified safe code.

## Test plan

- [ ] Verify the trivy scan workflow runs successfully with the SHA-pinned action
